### PR TITLE
Typechecker

### DIFF
--- a/Src/ChkRaw.hs
+++ b/Src/ChkRaw.hs
@@ -324,7 +324,10 @@ pout k p@(Prove g m (s, n) ps (h, b)) = let k' = scavenge b in case s of
 filth :: String -> String
 filth s = bifoldMap (($ "") . rfold lout) yuk (raw (fixities mySetup) s) where
   yuk (RawProof (Prove gr mr () ps src), ls) = case runAM go mySetup init of
-    Left e -> "{- " ++ show e ++ "\n" ++ rfold lout ls "\n-}"  -- shouldn't happen
+    Left e -> case runAM (ppGripe e) mySetup init of
+      Left _ -> "{- " ++ show e ++ "\n" ++ rfold lout ls "\n-}"
+      Right (e, _) ->
+         "{- " ++ e ++ "\n" ++ rfold lout ls "\n-}"
     Right (s, _) -> s
    where
     go :: AM String

--- a/Src/ChkRaw.hs
+++ b/Src/ChkRaw.hs
@@ -18,7 +18,7 @@ import Ask.Src.Lexing
 import Ask.Src.RawAsk
 import Ask.Src.Tm
 import Ask.Src.Glueing
-import Ask.Src.Scoping
+import Ask.Src.Typing
 import Ask.Src.Printing
 import Ask.Src.HardwiredRules
 

--- a/Src/ChkRaw.hs
+++ b/Src/ChkRaw.hs
@@ -33,7 +33,7 @@ data Status
   = Junk Gripe
   | Keep
   | Need
-  deriving (Show, Eq)
+  deriving Show
 
 passive :: Prove () Appl -> Prove Anno TmR
 passive (Prove g m () ps src) =
@@ -70,7 +70,7 @@ chkProof g m ps src = cope go junk return where
         From h@(_, (t, _, _) :$$ _) | elem t [Uid, Sym] -> do
           h@(Our ht _) <- scoApplTm Prop h
           (From h,) <$> ((TC "prove" [ht] :) <$> fromSubs gt ht)
-        From _ -> gripe FromNeedsConnective
+        From h -> gripe $ FromNeedsConnective h
         MGiven -> do
           given gt
           return (MGiven, [])
@@ -210,10 +210,12 @@ pout k p@(Prove g m (s, n) ps (h, b)) = let k' = scavenge b in case s of
     return $ (("prove " ++) . (g ++) . (" ?" ++) . whereFormat b ps
              $ format k' blk)
              :-/ Stop
-  Junk e -> return $
-    ("{- " ++ show e) :-/ [(Ret, (0,0), "\n")] :-\
-    (rfold lout h . rfold lout b $ "") :-/ [(Ret, (0,0), "\n")] :-\
-    "-}" :-/ Stop
+  Junk e -> do
+    e <- ppGripe e
+    return $
+      ("{- " ++ e) :-/ [(Ret, (0,0), "\n")] :-\
+      (rfold lout h . rfold lout b $ "") :-/ [(Ret, (0,0), "\n")] :-\
+      "-}" :-/ Stop
  where
    ((Key, p, s) : ls) `prove` n | elem s ["prove", "proven"] =
      (Key, p, "prove" ++ if n then "n" else "") : ls
@@ -230,10 +232,12 @@ pout k p@(Prove g m (s, n) ps (h, b)) = let k' = scavenge b in case s of
    subpout _ (SubPGuff ls)
      | all gappy ls = return $ rfold lout ls "" :-/ Stop
      | otherwise = return $ ("{- " ++ rfold lout ls " -}") :-/ Stop
-   subpout _ ((srg, gs) ::- Prove _ _ (Junk e, _) _ (h, b)) = return $
-     ("{- " ++ show e) :-/ [] :-\
-     (rfold lout srg . rfold lout h . rfold lout b $ "") :-/ [] :-\
-     "-}" :-/ Stop
+   subpout _ ((srg, gs) ::- Prove _ _ (Junk e, _) _ (h, b)) = do
+     e <- ppGripe e
+     return $
+       ("{- " ++ e) :-/ [] :-\
+       (rfold lout srg . rfold lout h . rfold lout b $ "") :-/ [] :-\
+       "-}" :-/ Stop
    subpout k ((srg, gs) ::- p) = fish gs (pout k p) >>= \case
      p :-/ b -> (:-/ b) <$>
        ((if null srg then givs gs else pure $ rfold lout srg) <*> pure p)

--- a/Src/ChkRaw.hs
+++ b/Src/ChkRaw.hs
@@ -22,7 +22,7 @@ import Ask.Src.Scoping
 import Ask.Src.Printing
 import Ask.Src.HardwiredRules
 
-track = trace
+track = const id
 
 type Anno =
   ( Status

--- a/Src/HardwiredRules.hs
+++ b/Src/HardwiredRules.hs
@@ -5,7 +5,7 @@ import qualified Data.Map as M
 import Ask.Src.Bwd
 import Ask.Src.Tm
 import Ask.Src.RawAsk
-import Ask.Src.Scoping
+import Ask.Src.Typing
 
 mySetup :: Setup
 mySetup = Setup

--- a/Src/HardwiredRules.hs
+++ b/Src/HardwiredRules.hs
@@ -9,9 +9,7 @@ import Ask.Src.Scoping
 
 mySetup :: Setup
 mySetup = Setup
-  { introRules = myIntroRules
-  , weirdRules = myWeirdRules
-  , fixities   = myFixities
+  { fixities   = myFixities
   }
 
 myFixities :: FixityTable
@@ -20,6 +18,16 @@ myFixities = M.fromList
   , ("|", (6, RAsso))
   , ("->", (1, RAsso))
   ]
+
+myPreamble :: Context
+myPreamble = B0
+  :< (("Type", []) ::> ("Prop", []))
+  :< (("Prop", []) ::> ("->", [("s", Prop), ("t", Prop)]))
+  :< (("Prop", []) ::> ("&", [("s", Prop), ("t", Prop)]))
+  :< (("Prop", []) ::> ("|", [("s", Prop), ("t", Prop)]))
+  :< (("Prop", []) ::> ("Not", [("s", Prop)]))
+  :< (("Prop", []) ::> ("False", []))
+  :< (("Prop", []) ::> ("True", []))
 
 myIntroRules :: [Rule]
 myIntroRules =
@@ -51,7 +59,7 @@ myWeirdRules =
   ]
 
 myContext :: Context
-myContext = B0
+myContext = myPreamble
   <>< [ByRule True  r | r <- myIntroRules]
   <>< [ByRule False r | r <- myWeirdRules]
 

--- a/Src/Makefile
+++ b/Src/Makefile
@@ -1,4 +1,4 @@
 default: ../bin/ask
 
-../bin/ask: OddEven.hs Bwd.hs HalfZip.hs Lexing.hs Parsing.hs Glueing.hs Printing.hs RawAsk.hs Thin.hs Tm.hs HardwiredRules.hs Scoping.hs ChkRaw.hs Main.hs
+../bin/ask: OddEven.hs Bwd.hs HalfZip.hs Lexing.hs Parsing.hs Glueing.hs Printing.hs RawAsk.hs Thin.hs Tm.hs HardwiredRules.hs Typing.hs ChkRaw.hs Main.hs
 	pushd ../.. ;  ghc --make -o ask/bin/ask ask/Src/Main.hs -main-is Ask.Src.Main.main ;  popd

--- a/Src/Printing.hs
+++ b/Src/Printing.hs
@@ -9,7 +9,7 @@ import Ask.Src.Lexing
 import Ask.Src.RawAsk
 import Ask.Src.Tm
 import Ask.Src.Glueing
-import Ask.Src.Scoping
+import Ask.Src.Typing
 
 data Spot = AllOK | RadSpot | Infix (Int, Either Assocy Assocy) | Fun | Arg deriving (Show, Eq)
 data Wot = Rad | Inf (Int, Assocy) | App deriving (Show, Eq)

--- a/Src/Printing.hs
+++ b/Src/Printing.hs
@@ -90,3 +90,40 @@ ppEl spot (f :$ s) = do
   s <-  ppTm Arg s
   return . pppa spot App $ f ++ " " ++ s
 
+ppGripe :: Gripe -> AM String
+ppGripe Surplus = return "I don't see why you need this"
+ppGripe (Scope x) = return $ "I can't find " ++ x ++ " in scope"
+ppGripe (ByBadRule r t) = do
+  t <- ppTm AllOK t
+  return $ "I can't find a rule called " ++ r ++ " that would prove " ++ t
+ppGripe (ByAmbiguous r t) = do
+  t <- ppTm AllOK t
+  return $ "Please report a bug: I have too many rules called " ++ r ++ " that would prove " ++ t
+ppGripe (FromNeedsConnective (ls, _)) = return $
+  rfold lout ls " has no main connective for 'from' to eliminate."
+ppGripe (NotGiven p) = do
+  p <- ppTm AllOK p
+  return $ "I do not remember being given " ++ p
+ppGripe (NotARule (ls, _)) = return $ rfold lout ls " is not the right shape to be a rule."
+ppGripe Mardiness = return $
+  "I seem to be unhappy but I can't articulate why, except that it's Conor's fault."
+ppGripe BadSubgoal = return "Please report a bug: I have found a badly structured subgoal."
+ppGripe (WrongNumOfArgs c n as) = return $
+  c ++ " expects " ++ count n ++ " but you have given it " ++ blat as
+  where
+  count 0 = "no arguments"
+  count 1 = "one argument"
+  count 2 = "two arguments"
+  count 3 = "three arguments"
+  count n = show n ++ " arguments"
+  blat [] = "none"
+  blat [(ls, _)] = rfold lout ls ""
+  blat ((ls, _) : as) = rfold lout ls $ " and " ++ blat as
+ppGripe (DoesNotMake c ty) = do
+  ty <- ppTm AllOK ty
+  return $ c ++ " cannot make a thing of type " ++ ty
+ppGripe (OverOverload c) = return $
+  "Please report a bug. " ++ c ++ " has unsafe overloading."
+ppGripe FAIL = return $
+  "It went wrong but I've forgotten how. Please ask a human for help."
+ppGripe g = return $ show g

--- a/Src/Scoping.hs
+++ b/Src/Scoping.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE CPP, TupleSections, LambdaCase, PatternSynonyms #-}
+{-# LANGUAGE CPP, TupleSections, LambdaCase, PatternSynonyms,
+    TypeSynonymInstances, FlexibleInstances #-}
 module Ask.Src.Scoping where
 
 import Data.List
@@ -9,6 +10,8 @@ import qualified Data.Map as M
 import Data.Foldable
 import Control.Arrow ((***))
 
+import Debug.Trace
+
 import Ask.Src.Bwd
 import Ask.Src.Thin
 import Ask.Src.Hide
@@ -17,6 +20,31 @@ import Ask.Src.Lexing
 import Ask.Src.RawAsk
 import Ask.Src.Tm
 import Ask.Src.Glueing
+
+track = trace
+
+type Context = Bwd CxE
+
+data CxE -- what sort of thing is in the context?
+  = Hyp Tm
+  | Var String  -- dear god no, fix this to be locally nameless
+  | Bind (Nom, Hide Tm) BKind
+  | ImplicitQuantifier
+  | (Con, [Pat]) ::> (Con, [(String, Tm)])
+  | ByRule Bool{- pukka intro?-} Rule
+  deriving (Show, Eq) -- get rid of that Eq!
+
+data Rule =
+  (Pat, (Con, [(String, Tm)])) :<=
+  [ Tm
+  ]
+  deriving (Show, Eq)
+
+data BKind
+  = User String
+  | Defn Tm
+  | Hole
+  deriving (Show, Eq)
 
 data Gripe
   = Surplus
@@ -29,6 +57,9 @@ data Gripe
   | ByAmbiguous
   | Mardiness
   | BadSubgoal
+  | WrongNumOfArgs Con
+  | DoesNotMake Con Con
+  | OverOverload Con
   | FAIL
   deriving (Show, Eq)
 
@@ -77,9 +108,7 @@ instance Alternative AM where
   ma <|> mb = cope ma (const mb) return
 
 data Setup = Setup
-  { introRules :: [Rule]
-  , weirdRules :: [Rule]
-  , fixities   :: FixityTable
+  { fixities   :: FixityTable
   } deriving Show
 
 fixity :: String -> AM (Int, Assocy)
@@ -88,13 +117,33 @@ fixity o = AM $ \ s as -> Right . (, as) $ case M.lookup o (fixities s) of
   Just x  -> x
 
 hnf :: Tm -> AM Tm
-hnf = return -- not for long
+hnf t = case t of
+  TC _ _ -> return t
+  TB _ -> return t
+  TE e -> upsilon <$> hnfSyn e
 
+upsilon :: Syn -> Tm
+upsilon (t ::: _) = t
+upsilon e = TE e
+
+hnfSyn :: Syn -> AM Syn
+hnfSyn e@(TP (x, Hide ty)) = do
+  nomBKind x >>= \case
+    Defn t -> return (t ::: ty)
+    _ -> return e
+hnfSyn (t ::: ty) = do
+  t <- hnf t
+  ty <- hnf ty
+  return (t ::: ty)
+hnfSyn (f :$ s) = hnfSyn f >>= \case
+  (TB b ::: TC "->" [dom, ran]) -> return ((b // (s ::: dom)) ::: ran)
+  f -> return (f :$ s)
+  
 equal :: Tm -> (Tm, Tm) -> AM ()
 equal ty (x, y) = guard $ x == y -- not for long
 
-maAM :: Pat -> Tm -> AM Matching
-maAM p t = go mempty (p, t) where
+maAM :: (Pat, Tm) -> AM Matching
+maAM (p, t) = go mempty (p, t) where
   go :: Thinning -> (Pat, Tm) -> AM Matching
   go ph (PM m th, t) = ((:[]) . (m,)) <$> mayhem (thicken th (t <^> ph))
   go ph (PC x ps, t) = do
@@ -107,12 +156,6 @@ maAM p t = go mempty (p, t) where
     TB (L t) -> go (os ph) (p, t)
     _ -> gripe FAIL
 
-data Rule =
-  (Pat, (String, [(Con, Tm)])) :<=
-  [ Tm
-  ]
-  deriving (Show, Eq)
-
 by :: Tm -> Appl -> AM (TmR, [Tm])
 by goal a@(_, (t, _, _) :$$ _) | elem t [Uid, Sym] = do
   subses <- fold <$> (gamma >>= traverse (backchain a))
@@ -124,7 +167,7 @@ by goal a@(_, (t, _, _) :$$ _) | elem t [Uid, Sym] = do
   backchain :: Appl -> CxE -> AM [(TmR, [Tm])] -- list of successes
   backchain a@(_, (_, _, r) :$$ ss) (ByRule _ ((gop, (h, ps)) :<= prems)) | h == r = cope (do
     let tmpl = TC r [TM x [] | (x, _) <- ps]
-    m <- maAM gop goal
+    m <- maAM (gop, goal)
     bs <- mayhem $ topSort <$> halfZip ps ss
     m <- argChk m bs
     return [(Our (stan m tmpl) a, stan m prems)]
@@ -144,26 +187,10 @@ invert :: Tm -> AM [((String, [(String, Tm)]), [Tm])]
 invert hyp = fold <$> (gamma >>= traverse try )
  where
   try :: CxE -> AM [((String, [(String, Tm)]), [Tm])]
-  try (ByRule True ((gop, vok) :<= prems)) = cope (maAM gop hyp)
+  try (ByRule True ((gop, vok) :<= prems)) = cope (maAM (gop, hyp))
     (\ _ -> return [])
     (\ m -> return [((id *** map (id *** stan m)) vok, stan m prems)])
   try _ = return []
-
-type Context = Bwd CxE
-
-data CxE -- what sort of thing is in the context?
-  = Hyp Tm
-  | Var String  -- dear god no, fix this to be locally nameless
-  | Bind (Nom, Hide Tm) BKind
-  | ImplicitQuantifier
-  | ByRule Bool{- pukka intro?-} Rule
-  deriving (Show, Eq) -- get rid of that Eq!
-
-data BKind
-  = User String
-  | Defn Tm
-  | Hole
-  deriving (Show, Eq)
 
 gamma :: AM Context
 gamma = AM $ \ setup as -> Right (context as, as)
@@ -231,9 +258,121 @@ scoApplTm ty a@(_, t) = ((`Our` a)) <$> go t
   where
     go :: Appl' -> AM Tm
     go ((t, _, y) :$$ ras) = case t of
-      Lid -> TE <$> (foldl (:$) <$> what's y <*> as)
-      _   -> TC y <$> as
-      where as = traverse (go . snd) ras
+      Lid -> do
+        (e, sy) <- synApps y ras
+        subtype sy ty
+        return $ TE e
+      _   -> do
+        TC d ss <- hnf ty
+        (fold <$> (gamma >>= traverse (try d ss y))) >>= \case
+          [] -> gripe (DoesNotMake y d)
+          _ : _ : _ -> gripe (OverOverload y)
+          [(m, as)] -> do
+            let tmpl = TC y [TM x [] | (x, _) <- as]
+            bs <- cope (mayhem $ topSort <$> halfZip as ras)
+                    (\ _ -> gripe (WrongNumOfArgs y))
+                    return
+            m <- argChk m bs
+            return $ stan m tmpl
+    try :: Con -> [Tm] -> Con -> CxE -> AM [(Matching, [(String, Tm)])]
+    try d ss c ((d', ps) ::> (c', as)) | d == d' && c == c' = do
+      m <- concat <$> ((mayhem $ halfZip ps ss) >>= traverse maAM)
+      return [(m, as)]
+    try _ _ _ _ = return []
+
+synApps :: String -> [Appl] -> AM (Syn, Tm)
+synApps f as = do
+  f@(TP (_, Hide t)) <- what's f
+  spinalApp (f, t) as
+
+spinalApp :: (Syn, Tm) -> [Appl] -> AM (Syn, Tm)
+spinalApp fsy [] = return fsy
+spinalApp (f, sy) (a : as) = do
+  (dom, ran) <- makeFun sy
+  Our s _ <- scoApplTm dom a
+  spinalApp (f :$ s, ran) as
+
+makeFun :: Tm -> AM (Tm, Tm)
+makeFun (TC "->" [dom, ran]) = return (dom, ran)
+makeFun _ = gripe FAIL -- could do better
+
+subtype :: Tm -> Tm -> AM ()
+subtype got want = unify (got, want)
+
+unify :: (Tm, Tm) -> AM ()
+unify (a, b) = do
+  a <- hnf a
+  b <- hnf b
+  True <- track (show a ++ " =? " ++ show b) (return True)
+  case (a, b) of
+    (TC f as, TC g bs) -> do
+      guard $ f == g
+      abs <- mayhem $ halfZip as bs
+      traverse unify abs
+      return ()
+    (TE (TP (x, _)), t) -> make x t
+    (s, TE (TP (y, _))) -> make y s
+    _ -> gripe FAIL
+
+make :: Nom -> Tm -> AM ()
+make x (TE (TP (y, _))) | x == y = return ()
+make x t = do
+  nomBKind x >>= \case
+    User _ -> gripe FAIL
+    Defn s -> unify (s, t)
+    Hole -> do
+      ga <- gamma
+      ga <- go ga []
+      setGamma ga
+ where
+  go B0 ms = gripe FAIL -- shouldn't happen
+  go (ga :< Bind p@(y, _) Hole) ms | x == y = do
+    pDep y (ms, t) >>= \case
+      True -> gripe FAIL
+      False -> return (ga <>< ms :< Bind p (Defn t))
+  go (ga :< Bind (y, _) _) ms | x == y = gripe FAIL
+  go (ga :< z@(Bind (y, _) k)) ms = do
+    pDep y (ms, t) >>= \case
+      False -> (:< z) <$> go ga ms
+      True -> case k of
+        User _ -> gripe FAIL
+        _ -> go ga (z : ms)
+  go (ga :< z) ms = (:< z) <$> go ga ms
+
+class PDep t where
+  pDep :: Nom -> t -> AM Bool
+
+instance PDep Tm where
+  pDep x t = do
+    hnf t >>= \case
+      TC _ ts -> pDep x ts
+      TB t -> pDep x t
+      TE e -> pDep x e
+
+instance PDep Syn where
+  pDep x (TP (y, _)) = return $ x == y
+  pDep x (t ::: ty) = (||) <$> pDep x t <*> pDep x ty
+  pDep x (e :$ s) =  (||) <$> pDep x e <*> pDep x s
+
+instance PDep t => PDep [t] where
+  pDep x ts = do
+    any id <$> traverse (pDep x) ts
+
+instance (PDep s, PDep t) => PDep (s, t) where
+  pDep x (s, t) = (||) <$> pDep x s <*> pDep x t
+
+instance PDep t => PDep (Bind t) where
+  pDep x (K t) = pDep x t
+  pDep x (L t) = pDep x t
+
+instance PDep CxE where
+  pDep x (Hyp p) = pDep x p
+  pDep x (Bind (_, Hide ty) k) = (||) <$> pDep x ty <*> pDep x k
+  pDep _ _ = return False
+
+instance PDep BKind where
+  pDep x (Defn t) = pDep x t
+  pDep _ _ = return False
 
 -- currently a knock-off, this checks that rules are good for props
 scoApplRu :: Tm -> Appl -> AM TmR

--- a/Src/Typing.hs
+++ b/Src/Typing.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE CPP, TupleSections, LambdaCase, PatternSynonyms,
     TypeSynonymInstances, FlexibleInstances #-}
-module Ask.Src.Scoping where
+module Ask.Src.Typing where
 
 import Data.List
 import Control.Monad


### PR DESCRIPTION
We're now typechecking the propositions which show up as goals and hypotheses. Admittedly, there are only two types just now: `Type` and `Prop`. But even that lets us diagnose nonsense much earlier and deliver a less zen UX.