### PR TITLE
Handle unification and constructor errors

### DIFF
--- a/Src/Context.hs
+++ b/Src/Context.hs
@@ -86,6 +86,7 @@ data Gripe
   | OverOverload Con
   | NonCanonicalType Tm Con
   | BadFName String
+  | Unification Con Con
   | FAIL
   deriving Show
 
@@ -132,6 +133,10 @@ instance Functor AM where fmap = ap . return
 
 gripe :: Gripe -> AM x
 gripe g = AM $ \ _ _ -> Left g
+
+guardErr :: Bool -> Gripe -> AM ()
+guardErr True _ = return ()
+guardErr False err = gripe err
 
 instance Fail.MonadFail AM where
   fail _ = gripe FAIL

--- a/Src/Printing.hs
+++ b/Src/Printing.hs
@@ -177,6 +177,9 @@ ppGripe (BadFName f) = return $ case f of
   _ -> "I'm afraid that " ++ f ++ " is an unsuitable name for a function."
 ppGripe (Unification found expected) =
   return $ "I was compelled to expect " ++ show expected ++ "but I was given " ++ show found ++ " instead"
+ppGripe (NonCanonicalType ty con) =
+  return $ show con ++ " is a constructor but I am not sure it should be there."
+
 ppGripe FAIL = return $
   "It went wrong but I've forgotten how. Please ask a human for help."
 ppGripe g = return $ show g

--- a/Src/Printing.hs
+++ b/Src/Printing.hs
@@ -175,7 +175,8 @@ ppGripe (BadFName f) = return $ case f of
       " but function names should begin in lowercase. (Did you mean data ... = "
       ++ f ++ " ...?)"
   _ -> "I'm afraid that " ++ f ++ " is an unsuitable name for a function."
-    
+ppGripe (Unification found expected) =
+  return $ "I was compelled to expect " ++ show expected ++ "but I was given " ++ show found ++ " instead"
 ppGripe FAIL = return $
   "It went wrong but I've forgotten how. Please ask a human for help."
 ppGripe g = return $ show g

--- a/Src/Typing.hs
+++ b/Src/Typing.hs
@@ -10,7 +10,7 @@
   , PatternSynonyms
   , TypeSynonymInstances
   , FlexibleInstances #-}
-  
+
 module Ask.Src.Typing where
 
 --import Data.List
@@ -393,7 +393,7 @@ unify ty a b = do  -- pay more attention to types
     (TC "$" [a, TE (TP (z, _)), i], TC "$" [b, TE (TP (y, _)), j])
       | z == y && i == j -> unify Type a b
     (TC f as, TC g bs) -> do
-      guard $ f == g
+      guardErr (f == g) (Unification f g)
       tel <- constructor ty f
       unifies tel as bs
     (TE (TP xp), t) -> make xp t ty
@@ -465,7 +465,7 @@ make xp@(x, Hide ty) t  got = do
       got <- case t of
         TE e -> eqSyn e e
         _ -> return got
-      subtype got ty 
+      subtype got ty
       ga <- gamma
       ga <- go ga []
       True <- track "MADE" $ return True
@@ -570,7 +570,7 @@ telify vs lox = go [] lox where
     User x -> e4p (xp, TM x [] ::: ty) <$> go ((x, (xp, ty)) : ps) lox
   go ps ((_ ::> _) : lox) = go ps lox
   go _ _ = gripe FAIL
-       
+
 schemify :: [String]  -- the explicit parameter order
          -> [CxE]     -- the local context (as returned by doorStep)
          -> Tm        -- the return type
@@ -594,8 +594,8 @@ schemify vs lox rt = go [] lox where
         Al ty <$> ((xp \\) <$> go ps lox)
   go ps ((_ ::> _) : lox) = go ps lox
   go _ _ = gripe FAIL
-       
-    
+
+
 ------------------------------------------------------------------------------
 --  Binding a Parameter List
 ------------------------------------------------------------------------------


### PR DESCRIPTION
`nonCanonicalConstructor` did not have a printing function, and unification errors were thrown with `FAIL` which is pretty uninformative. I've added an error with a custom message for unification